### PR TITLE
Array and string offset access syntax with curly braces is deprecated…

### DIFF
--- a/src/MD/Foundation/Utils/StringUtils.php
+++ b/src/MD/Foundation/Utils/StringUtils.php
@@ -657,7 +657,7 @@ class StringUtils
         
         $string = '';
         for ($i = 1; $i <= $length; $i++) {
-            $string .= $chars{mt_rand(0, strlen($chars) - 1)};
+            $string .= $chars[mt_rand(0, strlen($chars) - 1)];
         }
 
         return $string;


### PR DESCRIPTION
…. Replacing with brackets access.

https://wiki.php.net/rfc/deprecate_curly_braces_array_access